### PR TITLE
Fixing issues where serialport library is installed incorrectly

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "url": "git+https://github.com/norfolkjs/motorized-sumobot.git"
   },
   "dependencies": {
-    "johnny-five": "^0.15.0",
+    "serialport": "^7.1.5",
+    "johnny-five": "^1.2.0",
     "keypress": "^0.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
At least in Linux (And I think windows and Mac too) the serial port library needs to be installed FIRST.
I've also updated the reference to the latest johnny-five library.

To re-create the problem i'm fixing. clone this and just **npm i** it should install but then running the:
```node motor-sumo.js``` 
command will complain about **serialport** missing.

I'm on the latest Node 12.7

If anyone can confirm that on Mac or Windows this works just fine. then I suggest merging this as it'll help all the linux folks out there at the very least (if not fix future Mac or Windows issues)
